### PR TITLE
CHK-501: Fix Google API calls not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Bug that caused all requests to Google Maps API to fail.
 
 ## [0.3.0] - 2020-12-11
 ### Added

--- a/node/clients/Google.ts
+++ b/node/clients/Google.ts
@@ -4,20 +4,43 @@ import {
   PlaceDetailsRequest,
 } from '@googlemaps/google-maps-services-js'
 import { ExternalClient, IOContext, InstanceOptions } from '@vtex/api'
+import axios from 'axios'
 
 export class Google extends ExternalClient {
-  private externalClient: Client
+  private client: Client
+  private baseUrl = 'http://maps.googleapis.com'
+  private routes = {
+    placeAutocomplete: `${this.baseUrl}/maps/api/place/autocomplete/json`,
+    placeDetails: `${this.baseUrl}/maps/api/place/details/json`,
+  }
 
   constructor(context: IOContext, options?: InstanceOptions) {
     super('', context, options)
-    this.externalClient = new Client()
+
+    const axiosInstance = axios.create({
+      ...options,
+      baseURL: this.baseUrl,
+      headers: {
+        ...options?.headers,
+        'x-vtex-use-https': 'true',
+        'proxy-authorization': context.authToken,
+      },
+    })
+
+    this.client = new Client({ axiosInstance })
   }
 
   public placeAutocomplete(request: PlaceAutocompleteRequest) {
-    return this.externalClient.placeAutocomplete(request)
+    return this.client.placeAutocomplete({
+      ...request,
+      url: this.routes.placeAutocomplete,
+    })
   }
 
   public placeDetails(request: PlaceDetailsRequest) {
-    return this.externalClient.placeDetails(request)
+    return this.client.placeDetails({
+      ...request,
+      url: this.routes.placeDetails,
+    })
   }
 }

--- a/node/index.ts
+++ b/node/index.ts
@@ -4,7 +4,7 @@ import schema from 'vtex.geolocation-graphql-interface/graphql'
 import { Clients } from './clients'
 import { resolvers } from './resolvers'
 
-const DEFAULT_TIMEOUT_MS = 2 * 1000
+const DEFAULT_TIMEOUT_MS = 5 * 1000
 
 export default new Service<Clients, RecorderState, ParamsContext>({
   clients: {


### PR DESCRIPTION
#### What problem is this solving?

Although everything was working fine on development mode (that is, with the app linked), all calls to Google API, which are `address` and `addressSuggestion` queries, would return an error when _installed_ on a workspace.

The error `Client network socket disconnected before secure TLS connection was established` was happening because https://github.com/googlemaps/google-maps-services-js uses https under the hood (`https://maps.googleapis.com/`).

To fix this, all https calls must be delegated to IO by using the "x-vtex-use-https" header.

#### How should this be manually tested?

I made a [beta release](https://github.com/vtex-apps/google-geolocation-resolver/tree/v0.3.1-beta.1) for this PR, so just verifying that [this GraphiQL query](https://geolocation--checkoutio.myvtex.com/_v/private/vtex.geolocation-graphql-interface@0.2.0/graphiql/v1?query=%7B%0A%20%20addressSuggestions(searchTerm%3A%20%22praia%20de%20botafogo%2C%20200%22)%20%7B%0A%20%20%20%20description%0A%20%20%20%20mainText%0A%20%20%20%20mainTextMatchInterval%20%7B%0A%20%20%20%20%20%20offset%0A%20%20%20%20%20%20length%0A%20%20%20%20%7D%0A%20%20%20%20secondaryText%0A%20%20%20%20externalId%0A%20%20%7D%0A%20%20address(externalId%3A%20%22ChIJCYHbkYx_mQARKigvwNaXWVE%22)%20%7B%0A%20%20%20%20addressId%0A%20%20%20%20addressType%0A%20%20%20%20city%0A%20%20%20%20complement%0A%20%20%20%20country%0A%20%20%20%20neighborhood%0A%20%20%20%20number%0A%20%20%20%20postalCode%0A%20%20%20%20receiverName%0A%20%20%20%20reference%0A%20%20%20%20state%0A%20%20%20%20street%0A%20%20%7D%0A%7D%0A) works, should be enough.