### PR TITLE
CHK-502: False positive warning log for language codes with hyphen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- False positive warning log for languages with hyphen.
 
 ## [0.3.1] - 2020-12-15
 ### Fixed

--- a/node/__tests__/address.test.ts
+++ b/node/__tests__/address.test.ts
@@ -1,0 +1,83 @@
+import {
+  PlaceDetailsRequest,
+  PlaceDetailsResponse,
+  Status,
+} from '@googlemaps/google-maps-services-js'
+import { Apps, IOClients, IOContext } from '@vtex/api'
+import { QueryAddressArgs } from 'vtex.geolocation-graphql-interface'
+
+import { Clients } from '../clients'
+import { Google } from '../clients/Google'
+import getAddress from '../resolvers/address'
+
+const mockArgs = (): QueryAddressArgs => ({
+  externalId: 'id',
+  sessionToken: 'session token',
+})
+
+interface MockContextProps {
+  locale: string
+  warn: (warning: unknown) => void
+}
+
+const mockContext = ({ locale, warn }: MockContextProps): Context =>
+  ({
+    clients: {
+      google: {
+        placeDetails: (_request: PlaceDetailsRequest) =>
+          Promise.resolve({
+            statusText: Status.OK,
+            data: {},
+          } as PlaceDetailsResponse),
+      } as Google,
+      apps: {
+        getAppSettings: (_app: string) =>
+          Promise.resolve({
+            apiKey: 'api key',
+          } as { apiKey: string }),
+      } as Apps,
+    } as IOClients & Clients,
+    vtex: {
+      locale,
+      logger: {
+        warn,
+        error: (_error: unknown) => undefined,
+      },
+    } as IOContext,
+  } as Context)
+
+describe('address', () => {
+  it.each(['pt-BR', 'en'])(
+    'shouldn\'t log "%s" as invalid language code',
+    async (language: string) => {
+      const mockWarn = jest.fn((_warning: unknown) => undefined)
+
+      await getAddress(
+        {},
+        mockArgs(),
+        mockContext({ locale: language, warn: mockWarn })
+      )
+
+      expect(mockWarn).not.toBeCalledWith(
+        `"${language}" is not a valid language. See the list of supported languages on https://developers.google.com/maps/faq#languagesupport`
+      )
+    }
+  )
+
+  it.each(['pt_BR', ''])(
+    'should log "%s" as invalid language code',
+    async (language) => {
+      const mockWarn = jest.fn((_warning: unknown) => undefined)
+
+      await getAddress(
+        {},
+        mockArgs(),
+        mockContext({ locale: language, warn: mockWarn })
+      )
+
+      expect(mockWarn).toBeCalledWith(
+        `"${language}" is not a valid language. See the list of supported languages on https://developers.google.com/maps/faq#languagesupport`
+      )
+    }
+  )
+})

--- a/node/__tests__/addressSuggestion.test.ts
+++ b/node/__tests__/addressSuggestion.test.ts
@@ -1,0 +1,86 @@
+import {
+  PlaceAutocompleteRequest,
+  PlaceAutocompleteResponse,
+  Status,
+  PlaceAutocompleteResult,
+} from '@googlemaps/google-maps-services-js'
+import { Apps, IOClients, IOContext } from '@vtex/api'
+import { QueryAddressSuggestionsArgs } from 'vtex.geolocation-graphql-interface'
+
+import { Clients } from '../clients'
+import { Google } from '../clients/Google'
+import getAddressSuggestions from '../resolvers/addressSuggestions'
+
+const mockArgs = (): QueryAddressSuggestionsArgs => ({
+  searchTerm: 'search term',
+  sessionToken: 'session token',
+})
+
+interface MockContextProps {
+  locale: string
+  warn: (warning: unknown) => void
+}
+
+const mockContext = ({ locale, warn }: MockContextProps): Context =>
+  ({
+    clients: {
+      google: {
+        placeAutocomplete: (_request: PlaceAutocompleteRequest) =>
+          Promise.resolve({
+            statusText: Status.OK,
+            data: {
+              predictions: [] as PlaceAutocompleteResult[],
+            },
+          } as PlaceAutocompleteResponse),
+      } as Google,
+      apps: {
+        getAppSettings: (_app: string) =>
+          Promise.resolve({
+            apiKey: 'api key',
+          } as { apiKey: string }),
+      } as Apps,
+    } as IOClients & Clients,
+    vtex: {
+      locale,
+      logger: {
+        warn,
+        error: (_error: unknown) => undefined,
+      },
+    } as IOContext,
+  } as Context)
+
+describe('addressSuggestion', () => {
+  it.each(['pt-BR', 'en'])(
+    'shouldn\'t log "%s" as invalid language code',
+    async (language: string) => {
+      const mockWarn = jest.fn((_warning: unknown) => undefined)
+
+      await getAddressSuggestions(
+        {},
+        mockArgs(),
+        mockContext({ locale: language, warn: mockWarn })
+      )
+
+      expect(mockWarn).not.toBeCalledWith(
+        `"${language}" is not a valid language. See the list of supported languages on https://developers.google.com/maps/faq#languagesupport`
+      )
+    }
+  )
+
+  it.each(['pt_BR', ''])(
+    'should log "%s" as invalid language code',
+    async (language) => {
+      const mockWarn = jest.fn((_warning: unknown) => undefined)
+
+      await getAddressSuggestions(
+        {},
+        mockArgs(),
+        mockContext({ locale: language, warn: mockWarn })
+      )
+
+      expect(mockWarn).toBeCalledWith(
+        `"${language}" is not a valid language. See the list of supported languages on https://developers.google.com/maps/faq#languagesupport`
+      )
+    }
+  )
+})

--- a/node/resolvers/address.ts
+++ b/node/resolvers/address.ts
@@ -1,11 +1,10 @@
 import {
   Status,
-  Language,
   AddressType,
   Place,
   AddressGeometry,
+  Language,
 } from '@googlemaps/google-maps-services-js'
-import { IOContext } from '@vtex/api'
 import { Address, QueryAddressArgs } from 'vtex.geolocation-graphql-interface'
 
 import countryRules from '../countries/rules'
@@ -36,18 +35,6 @@ function getCountry(place: Place) {
     : null
 }
 
-function getLanguage(vtex: IOContext) {
-  const language = vtex.locale?.replace('_', '-') ?? ''
-
-  if (!(language in Language)) {
-    vtex.logger.warn(
-      `"${language}" is not a valid language. See the list of supported languages on https://developers.google.com/maps/faq#languagesupport`
-    )
-  }
-
-  return language as Language
-}
-
 const getAddress = async (
   _: unknown,
   args: QueryAddressArgs,
@@ -63,10 +50,16 @@ const getAddress = async (
     vtex.logger.warn('No session token found. Additional charges may apply')
   }
 
+  if (!Object.values(Language).includes(vtex.locale as Language)) {
+    vtex.logger.warn(
+      `"${vtex.locale}" is not a valid language. See the list of supported languages on https://developers.google.com/maps/faq#languagesupport`
+    )
+  }
+
   const response = await client.placeDetails({
     params: {
       place_id: externalId,
-      language: getLanguage(vtex),
+      language: vtex.locale ? (vtex.locale as Language) : undefined,
       sessiontoken: sessionToken ?? undefined,
       key: apiKey,
     },

--- a/node/resolvers/addressSuggestions.ts
+++ b/node/resolvers/addressSuggestions.ts
@@ -3,23 +3,10 @@ import {
   PlaceAutocompleteType,
   Status,
 } from '@googlemaps/google-maps-services-js'
-import { IOContext } from '@vtex/api'
 import {
   AddressSuggestion,
   QueryAddressSuggestionsArgs,
 } from 'vtex.geolocation-graphql-interface'
-
-function getLanguage(vtex: IOContext) {
-  const language = vtex.locale?.replace('_', '-') ?? ''
-
-  if (!(language in Language)) {
-    vtex.logger.warn(
-      `"${language}" is not a valid language. See the list of supported languages on https://developers.google.com/maps/faq#languagesupport`
-    )
-  }
-
-  return language as Language
-}
 
 const getAddressSuggestions = async (
   _: unknown,
@@ -36,10 +23,16 @@ const getAddressSuggestions = async (
     vtex.logger.warn('No session token found. Additional charges may apply')
   }
 
+  if (!Object.values(Language).includes(vtex.locale as Language)) {
+    vtex.logger.warn(
+      `"${vtex.locale}" is not a valid language. See the list of supported languages on https://developers.google.com/maps/faq#languagesupport`
+    )
+  }
+
   const response = await client.placeAutocomplete({
     params: {
       input: searchTerm,
-      language: getLanguage(vtex),
+      language: vtex.locale,
       types: PlaceAutocompleteType.address,
       sessiontoken: sessionToken ?? undefined,
       key: apiKey,

--- a/node/resolvers/providerLogo.ts
+++ b/node/resolvers/providerLogo.ts
@@ -11,13 +11,8 @@ const ALT_TEXT = 'Google logo'
 const getProviderLogo = async (
   _: unknown,
   _args: unknown,
-  ctx: Context
+  { clients: { apps }, vtex: { host } }: Context
 ): Promise<Image> => {
-  const {
-    clients: { apps },
-    vtex: { host },
-  } = ctx
-
   const appId = process.env.VTEX_APP_ID
   const appManifest = await apps.getApp(appId)
   const linked = appManifest.version.includes('+')


### PR DESCRIPTION
#### What problem is this solving?

All language codes with hyphen (like `pt-BR`) were being logged on splunk as invalid languages, as the validation was wrong. This PR fixes that and do some other refactors.

#### How should this be manually tested?

- [Run this GraphQL query](https://geolocation--checkoutio.myvtex.com/_v/private/vtex.geolocation-graphql-interface@0.2.0/graphiql/v1?query=%7B%0A%20%20address(externalId%3A%20%22ChIJCYHbkYx_mQARKigvwNaXWVE%22)%20%7B%0A%20%20%20%20addressId%0A%20%20%20%20addressType%0A%20%20%20%20city%0A%20%20%20%20complement%0A%20%20%20%20country%0A%20%20%20%20neighborhood%0A%20%20%20%20number%0A%20%20%20%20postalCode%0A%20%20%20%20receiverName%0A%20%20%20%20reference%0A%20%20%20%20state%0A%20%20%20%20street%0A%20%20%7D%0A%7D%0A)
- Assert that no warning shows up on [this splunk query](https://splunk7.vtex.com/en-US/app/search/search?q=search%20index%3Dio_vtex_logs%20app%3D%22vtex.google-geolocation-resolver%400.3.1%22%20account%3Dcheckoutio%20workspace%3Dgeolocation%20level%3Dwarn&sid=1608148519.12840045_1AEF2693-B8D7-45B3-B372-E433F69F2545&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=&earliest=-5m%40m&latest=now).

#### Checklist/Reminders

- [x] Linked this PR to a JIRA story (if applicable).
- [x] Updated/created tests.
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Notes

Fyi, all languages that google support: https://developers.google.com/maps/faq#languagesupport