### PR TITLE
CHK-469: Address suggestions restricted by country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Reduced costs when using address query.
+- Handle and log Google errors when inner response status code differs from OK.
+
+### Added
+- Handle country argument on address suggestions query.
 
 ## [0.3.2] - 2020-12-21
 ### Fixed

--- a/node/__mocks__/context.mock.ts
+++ b/node/__mocks__/context.mock.ts
@@ -1,0 +1,53 @@
+import {
+  PlaceAutocompleteRequest,
+  Status,
+  PlaceAutocompleteResult,
+  PlaceAutocompleteResponse,
+} from '@googlemaps/google-maps-services-js'
+import { Apps, IOClients, IOContext } from '@vtex/api'
+
+import { Clients } from '../clients'
+import { Google } from '../clients/Google'
+
+export const defaultWarn = (_warning: unknown) => undefined
+export const defaultPlaceAutocomplete = (_request: PlaceAutocompleteRequest) =>
+  Promise.resolve({
+    statusText: Status.OK,
+    data: {
+      predictions: [] as PlaceAutocompleteResult[],
+    },
+  } as PlaceAutocompleteResponse)
+
+interface MockContextProps {
+  locale?: string
+  mockedWarn?: (warning: unknown) => void
+  mockedPlaceAutocomplete?: (
+    request: PlaceAutocompleteRequest
+  ) => Promise<PlaceAutocompleteResponse>
+}
+
+export const mockContext = ({
+  locale = undefined,
+  mockedWarn = defaultWarn,
+  mockedPlaceAutocomplete = defaultPlaceAutocomplete,
+}: MockContextProps): Context =>
+  ({
+    clients: {
+      google: {
+        placeAutocomplete: mockedPlaceAutocomplete,
+      } as Google,
+      apps: {
+        getAppSettings: (_app: string) =>
+          Promise.resolve({
+            apiKey: 'api key',
+          } as { apiKey: string }),
+      } as Apps,
+    } as IOClients & Clients,
+    vtex: {
+      locale,
+      logger: {
+        warn: mockedWarn,
+        error: (_error: unknown) => undefined,
+      },
+    } as IOContext,
+  } as Context)

--- a/node/__tests__/addressSuggestion.test.ts
+++ b/node/__tests__/addressSuggestion.test.ts
@@ -1,67 +1,24 @@
-import {
-  PlaceAutocompleteRequest,
-  PlaceAutocompleteResponse,
-  Status,
-  PlaceAutocompleteResult,
-} from '@googlemaps/google-maps-services-js'
-import { Apps, IOClients, IOContext } from '@vtex/api'
-import { QueryAddressSuggestionsArgs } from 'vtex.geolocation-graphql-interface'
-
-import { Clients } from '../clients'
-import { Google } from '../clients/Google'
 import getAddressSuggestions from '../resolvers/addressSuggestions'
-
-const mockArgs = (): QueryAddressSuggestionsArgs => ({
-  searchTerm: 'search term',
-  sessionToken: 'session token',
-})
-
-interface MockContextProps {
-  locale: string
-  warn: (warning: unknown) => void
-}
-
-const mockContext = ({ locale, warn }: MockContextProps): Context =>
-  ({
-    clients: {
-      google: {
-        placeAutocomplete: (_request: PlaceAutocompleteRequest) =>
-          Promise.resolve({
-            statusText: Status.OK,
-            data: {
-              predictions: [] as PlaceAutocompleteResult[],
-            },
-          } as PlaceAutocompleteResponse),
-      } as Google,
-      apps: {
-        getAppSettings: (_app: string) =>
-          Promise.resolve({
-            apiKey: 'api key',
-          } as { apiKey: string }),
-      } as Apps,
-    } as IOClients & Clients,
-    vtex: {
-      locale,
-      logger: {
-        warn,
-        error: (_error: unknown) => undefined,
-      },
-    } as IOContext,
-  } as Context)
+// eslint-disable-next-line jest/no-mocks-import
+import {
+  mockContext,
+  defaultWarn,
+  defaultPlaceAutocomplete,
+} from '../__mocks__/context.mock'
 
 describe('addressSuggestion', () => {
   it.each(['pt-BR', 'en'])(
     'shouldn\'t log "%s" as invalid language code',
     async (language: string) => {
-      const mockWarn = jest.fn((_warning: unknown) => undefined)
+      const mockedWarn = jest.fn((_warning: unknown) => undefined)
 
       await getAddressSuggestions(
         {},
-        mockArgs(),
-        mockContext({ locale: language, warn: mockWarn })
+        { searchTerm: '' },
+        mockContext({ locale: language, mockedWarn })
       )
 
-      expect(mockWarn).not.toBeCalledWith(
+      expect(mockedWarn).not.toBeCalledWith(
         `"${language}" is not a valid language. See the list of supported languages on https://developers.google.com/maps/faq#languagesupport`
       )
     }
@@ -69,18 +26,75 @@ describe('addressSuggestion', () => {
 
   it.each(['pt_BR', ''])(
     'should log "%s" as invalid language code',
-    async (language) => {
-      const mockWarn = jest.fn((_warning: unknown) => undefined)
+    async (language: string) => {
+      const mockedWarn = jest.fn((_warning: unknown) => undefined)
 
       await getAddressSuggestions(
         {},
-        mockArgs(),
-        mockContext({ locale: language, warn: mockWarn })
+        { searchTerm: '' },
+        mockContext({ locale: language, mockedWarn })
       )
 
-      expect(mockWarn).toBeCalledWith(
+      expect(mockedWarn).toBeCalledWith(
         `"${language}" is not a valid language. See the list of supported languages on https://developers.google.com/maps/faq#languagesupport`
       )
     }
   )
+
+  it.each(['br', 'bra', 'BR', 'BRA'])(
+    'should restrict address suggestions to Brazil when the "%s" country code is given',
+    async (country: string) => {
+      const mockedWarn = jest.fn(defaultWarn)
+      const mockedPlaceAutocomplete = jest.fn(defaultPlaceAutocomplete)
+
+      await getAddressSuggestions(
+        {},
+        { searchTerm: '', country },
+        mockContext({ mockedPlaceAutocomplete, mockedWarn })
+      )
+
+      expect(mockedPlaceAutocomplete.mock.calls[0][0]).toMatchObject({
+        params: { components: ['country:br'] },
+      })
+      expect(mockedWarn).not.toBeCalledWith(
+        `"${country}" is not a valid country code. Use a two character, case insensitive, ISO 3166-1 Alpha-2 or Alpha-3 compatible country code instead.`
+      )
+    }
+  )
+
+  it('should not restrict address suggestions when no country code is given', async () => {
+    const mockedWarn = jest.fn(defaultWarn)
+    const mockedPlaceAutocomplete = jest.fn(defaultPlaceAutocomplete)
+
+    await getAddressSuggestions(
+      {},
+      { searchTerm: '' },
+      mockContext({ mockedPlaceAutocomplete, mockedWarn })
+    )
+
+    expect(mockedPlaceAutocomplete.mock.calls[0][0]).toMatchObject({
+      params: { components: undefined },
+    })
+    expect(mockedWarn).not.toBeCalledWith(
+      '"" is not a valid country code. Use a two character, case insensitive, ISO 3166-1 Alpha-2 or Alpha-3 compatible country code instead.'
+    )
+  })
+
+  it('should not restrict address suggestions when an invalid country code is given', async () => {
+    const mockedWarn = jest.fn(defaultWarn)
+    const mockedPlaceAutocomplete = jest.fn(defaultPlaceAutocomplete)
+
+    await getAddressSuggestions(
+      {},
+      { searchTerm: '', country: 'Brazil' },
+      mockContext({ mockedPlaceAutocomplete, mockedWarn })
+    )
+
+    expect(mockedPlaceAutocomplete.mock.calls[0][0]).toMatchObject({
+      params: { components: undefined },
+    })
+    expect(mockedWarn).toBeCalledWith(
+      '"Brazil" is not a valid country code. Use a two character, case insensitive, ISO 3166-1 Alpha-2 or Alpha-3 compatible country code instead.'
+    )
+  })
 })

--- a/node/countries/ISO.ts
+++ b/node/countries/ISO.ts
@@ -261,3 +261,11 @@ export const toAlpha2 = (country: ISOAlpha3): ISOAlpha2 => {
 
   return countryISOMapping[index][0]
 }
+
+export const isAlpha2 = (country: string): boolean => {
+  return countryISOMapping.findIndex(([alpha2]) => alpha2 === country) !== -1
+}
+
+export const isAlpha3 = (country: string): boolean => {
+  return countryISOMapping.findIndex(([, alpha3]) => alpha3 === country) !== -1
+}

--- a/node/package.json
+++ b/node/package.json
@@ -6,13 +6,13 @@
   "dependencies": {
     "uuid": "^8.3.1",
     "@googlemaps/google-maps-services-js": "^3.1.6",
-    "vtex.geolocation-graphql-interface": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.2.0/public"
+    "vtex.geolocation-graphql-interface": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.3.0/public"
   },
   "devDependencies": {
     "@types/googlemaps": "^3.39.13",
     "@types/jest": "^26.0.16",
     "@types/uuid": "^8.3.0",
-    "@types/vtex.geolocation-graphql-interface": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.2.0/public/@types/vtex.geolocation-graphql-interface",
+    "@types/vtex.geolocation-graphql-interface": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.3.0/public/@types/vtex.geolocation-graphql-interface",
     "@vtex/api": "6.37.1",
     "@vtex/test-tools": "^3.3.2",
     "vtex.messages": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.60.2/public/@types/vtex.messages"

--- a/node/resolvers/address.ts
+++ b/node/resolvers/address.ts
@@ -62,11 +62,13 @@ const getAddress = async (
     timeout: 1000,
   })
 
-  if (response.statusText !== Status.OK) {
-    logger.error(response)
-  }
+  const { result: place, status } = response.data
 
-  const { result: place } = response.data
+  if (response.statusText !== 'OK' || status !== Status.OK) {
+    logger.error(response)
+
+    return {}
+  }
 
   const country = getCountry(place)
 

--- a/node/resolvers/address.ts
+++ b/node/resolvers/address.ts
@@ -57,6 +57,7 @@ const getAddress = async (
       place_id: externalId,
       language: locale ? (locale as Language) : undefined,
       sessiontoken: sessionToken ?? undefined,
+      fields: ['address_component', 'geometry'],
       key: apiKey,
     },
     timeout: 1000,

--- a/node/resolvers/addressSuggestions.ts
+++ b/node/resolvers/addressSuggestions.ts
@@ -8,9 +8,26 @@ import {
   QueryAddressSuggestionsArgs,
 } from 'vtex.geolocation-graphql-interface'
 
+import { isAlpha2, isAlpha3, toAlpha2 } from '../countries/ISO'
+import { ISOAlpha3 } from '../countries/types'
+
+const toValidCountry = (country?: string | null) => {
+  let validCountry = country?.toUpperCase() ?? ''
+
+  if (isAlpha3(validCountry)) {
+    validCountry = toAlpha2(validCountry as ISOAlpha3)
+  } else if (!isAlpha2(validCountry)) {
+    validCountry = ''
+  }
+
+  validCountry = validCountry.toLowerCase()
+
+  return validCountry || null
+}
+
 const getAddressSuggestions = async (
   _: unknown,
-  { searchTerm, sessionToken }: QueryAddressSuggestionsArgs,
+  { searchTerm, sessionToken, country }: QueryAddressSuggestionsArgs,
   { clients: { apps, google }, vtex: { logger, locale } }: Context
 ): Promise<AddressSuggestion[]> => {
   const { apiKey } = await apps.getAppSettings(process.env.VTEX_APP_ID)
@@ -25,11 +42,20 @@ const getAddressSuggestions = async (
     )
   }
 
+  const validCountry = toValidCountry(country)
+
+  if (country && !validCountry) {
+    logger.warn(
+      `"${country}" is not a valid country code. Use a two character, case insensitive, ISO 3166-1 Alpha-2 or Alpha-3 compatible country code instead.`
+    )
+  }
+
   const response = await google.placeAutocomplete({
     params: {
       input: searchTerm,
       language: locale,
       types: PlaceAutocompleteType.address,
+      components: validCountry ? [`country:${validCountry}`] : undefined,
       sessiontoken: sessionToken ?? undefined,
       key: apiKey,
     },

--- a/node/resolvers/addressSuggestions.ts
+++ b/node/resolvers/addressSuggestions.ts
@@ -62,13 +62,25 @@ const getAddressSuggestions = async (
     timeout: 1000,
   })
 
-  if (response.statusText !== Status.OK) {
+  if (response.statusText !== 'OK') {
     logger.error(response)
 
     return []
   }
 
-  return response.data.predictions.map(
+  const { status, predictions } = response.data
+
+  if (status !== Status.OK) {
+    if (status === Status.ZERO_RESULTS) {
+      logger.warn(response)
+    } else {
+      logger.error(response)
+    }
+
+    return []
+  }
+
+  return predictions.map(
     ({
       description,
       place_id: externalId,

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1554,9 +1554,9 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
   integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
 
-"@types/vtex.geolocation-graphql-interface@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.2.0/public/@types/vtex.geolocation-graphql-interface":
-  version "0.2.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.2.0/public/@types/vtex.geolocation-graphql-interface#eee30f5c90617f351b132bd6447f7c88150cba94"
+"@types/vtex.geolocation-graphql-interface@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.3.0/public/@types/vtex.geolocation-graphql-interface":
+  version "0.3.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.3.0/public/@types/vtex.geolocation-graphql-interface#7d8c16d1c0e71d7337afcbabaf4c0a2811d60a3b"
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -5937,9 +5937,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.geolocation-graphql-interface@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.2.0/public":
+"vtex.geolocation-graphql-interface@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.3.0/public":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.2.0/public#9a68fec64e064d2c72f66aceac48a3c3688e158f"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.geolocation-graphql-interface@0.3.0/public#4f57a09d47e44fe4d024b1568ac103fb10b1ee39"
 
 "vtex.messages@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.messages@1.60.2/public/@types/vtex.messages":
   version "1.60.2"


### PR DESCRIPTION
#### What problem is this solving?

As title says. Depends on https://github.com/vtex-apps/geolocation-graphql-interface/pull/7.

#### How should this be manually tested?

- Try [this query](https://geolocation--checkoutio.myvtex.com/_v/private/vtex.geolocation-graphql-interface@0.2.0/graphiql/v1?query=%7B%0A%20%20addressSuggestions(searchTerm%3A%20%22a%22%2C%20country%3A%20%22br%22)%20%7B%0A%20%20%20%20description%0A%20%20%7D%0A%7D)
- Notice that searching by "a" returns things like "avenida"
- [Remove country param from the query](https://geolocation--checkoutio.myvtex.com/_v/private/vtex.geolocation-graphql-interface@0.2.0/graphiql/v1?query=%7B%0A%20%20addressSuggestions(searchTerm%3A%20%22a%22)%20%7B%0A%20%20%20%20description%0A%20%20%7D%0A%7D)
- It should return addresses from USA

#### Checklist/Reminders

- [x] Linked this PR to a JIRA story (if applicable).
- [x] Updated/created tests.
- [ ] Deleted the workspace after merging this PR (if applicable).
