### PR TITLE
Added country rules for Romania

### DIFF
--- a/node/countries/ROU.ts
+++ b/node/countries/ROU.ts
@@ -1,0 +1,40 @@
+const rules: Rules = {
+  geolocation: {
+    postalCode: {
+      valueIn: 'long_name',
+      types: ['postal_code'],
+      required: false,
+    },
+    number: {
+      valueIn: 'long_name',
+      types: ['street_number'],
+      required: true,
+      notApplicable: true,
+    },
+    street: {
+      valueIn: 'long_name',
+      types: ['route'],
+    },
+    neighborhood: {
+      valueIn: 'long_name',
+      types: [
+        'neighborhood',
+        'sublocality_level_1',
+        'sublocality_level_2',
+        'sublocality_level_3',
+        'sublocality_level_4',
+        'sublocality_level_5',
+      ],
+    },
+    state: {
+      valueIn: 'long_name',
+      types: ['administrative_area_level_1'],
+    },
+    city: {
+      valueIn: 'short_name',
+      types: ['administrative_area_level_2', 'locality'],
+    },
+  },
+}
+
+export default rules

--- a/node/countries/rules.ts
+++ b/node/countries/rules.ts
@@ -3,12 +3,14 @@ import ARG from './ARG'
 import BOL from './BOL'
 import BRA from './BRA'
 import USA from './USA'
+import ROU from './ROU'
 
 const rules: { [key in ISOAlpha3]?: Rules } = {
   ARG,
   BOL,
   BRA,
   USA,
+  ROU,
 }
 
 export default rules


### PR DESCRIPTION
#### What problem is this solving?
This pull request adds country rules for Romania (ROU) in node. This allows us to use google geolocation queries for stores located in Romania.
